### PR TITLE
ipq807x: add support for Aliyun AP8220

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-<img src="https://avatars.githubusercontent.com/u/53193414?s=200&v=4" alt="logo" width="200" height="200" align="right">
+# Project ImmortalWrt - Aliyun AP8220
 
-# Project ImmortalWrt
+<img src="https://avatars.githubusercontent.com/u/53193414?s=200&v=4" alt="logo" width="200" height="200" align="right">
 
 ImmortalWrt is a fork of [OpenWrt](https://openwrt.org), with more packages ported, more devices supported, default optimized profiles and localization modifications for mainland China users.<br/>
 Compared to upstream, we allow to use (non-upstreamable) modifications/hacks to provide better feature/performance/support.

--- a/package/boot/uboot-envtools/files/qualcommax_ipq807x
+++ b/package/boot/uboot-envtools/files/qualcommax_ipq807x
@@ -19,7 +19,8 @@ netgear,wax630)
 	;;
 compex,wpq873|\
 edgecore,eap102|\
-zyxel,nbg7815)
+zyxel,nbg7815|\
+aliyun,ap8220)
 	idx="$(find_mtd_index 0:appsblenv)"
 	[ -n "$idx" ] && \
 		ubootenv_add_uci_config "/dev/mtd$idx" "0x0" "0x10000" "0x10000" "1"

--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8071-ap8220.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8071-ap8220.dts
@@ -1,0 +1,355 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+/dts-v1/;
+
+#include "ipq8074.dtsi"
+#include "ipq8074-ac-cpu.dtsi"
+#include "ipq8074-ess.dtsi"
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	model = "Aliyun AP8220";
+	compatible = "aliyun,ap8220", "qcom,ipq8074";
+
+	aliases {
+		serial0 = &blsp1_uart5;
+		led-boot = &led_pwr;
+		led-failsafe = &led_pwr;
+		led-running = &led_pwr;
+		led-upgrade = &led_pwr;
+	};
+
+	chosen {
+		stdout-path = "serial0:115200n8";
+		bootargs-append = " root=/dev/ubiblock0_1 swiotlb=1 coherent_pool=2M";
+	};
+
+	keys {
+		compatible = "gpio-keys";
+		pinctrl-0 = <&button_pins>;
+		pinctrl-names = "default";
+
+		reset {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&tlmm 0x42 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+		pinctrl-0 = <&led_pins>;
+		pinctrl-names = "default";
+
+		led_pwr: power {
+			label = "pwr";
+			gpio = <&tlmm 0x2e GPIO_ACTIVE_HIGH>;
+		};
+
+		led_2g: 2g {
+			label = "wlan2g";
+			gpio = <&tlmm 0x2f GPIO_ACTIVE_HIGH>;
+		};
+
+		led_5g: 5g {
+			label = "wlan5g";
+			gpio = <&tlmm 0x30 GPIO_ACTIVE_HIGH>;
+		};
+
+		led_ble: ble {
+			label = "ble";
+			gpio = <&tlmm 0x32 GPIO_ACTIVE_HIGH>;
+		};
+	};
+};
+
+&tlmm {
+	button_pins: button_pins {
+		phandle = <0x52>;
+
+		wps_button {
+			pins = "gpio66";
+			function = "gpio";
+			drive-strength = <0x08>;
+			bias-pull-up;
+		};
+	};
+
+	usb_mux_pins {
+
+		mux {
+			pins = "gpio27";
+			function = "gpio";
+			drive-strength = <0x08>;
+			bias-pull-down;
+		};
+	};
+
+	pcie_pins {
+
+		pcie0_rst {
+			pins = "gpio58";
+			function = "pcie0_rst";
+			drive-strength = <0x08>;
+			bias-pull-down;
+		};
+
+		pcie0_wake {
+			pins = "gpio59";
+			function = "pcie0_wake";
+			drive-strength = <0x08>;
+			bias-pull-down;
+		};
+	};
+
+	mdio_pins: mdio-pins {
+		phandle = <0x27>;
+
+		mux_0 {
+			pins = "gpio68";
+			function = "mdc";
+			drive-strength = <0x08>;
+			bias-pull-up;
+		};
+
+		mux_1 {
+			pins = "gpio69";
+			function = "mdio";
+			drive-strength = <0x08>;
+			bias-pull-up;
+		};
+
+		mux_2 {
+			pins = "gpio33";
+			function = "gpio";
+			bias-pull-up;
+		};
+
+		mux_3 {
+			pins = "gpio44";
+			function = "gpio";
+			bias-pull-up;
+		};
+	};
+
+	led_pins: led-pins {
+		phandle = <0x53>;
+
+		led_pwr {
+			pins = "gpio46";
+			function = "gpio";
+			drive-strength = <0x02>;
+			bias-pull-up;
+		};
+
+		led_2g {
+			pins = "gpio47";
+			function = "gpio";
+			drive-strength = <0x02>;
+			bias-pull-down;
+		};
+
+		led_5g {
+			pins = "gpio48";
+			function = "gpio";
+			drive-strength = <0x02>;
+			bias-pull-down;
+		};
+
+		led_ble {
+			pins = "gpio50";
+			function = "gpio";
+			drive-strength = <0x02>;
+			bias-pull-down;
+		};
+	};
+
+};
+
+&blsp1_spi1 {
+	pinctrl-0 = <&spi_0_pins>;
+	pinctrl-names = "default";
+	cs-select = <0>;
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
+		reg = <0>;
+		spi-max-frequency = <50000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "0:SBL1";
+				reg = <0x00 0x50000>;
+			};
+
+			partition@50000 {
+				label = "0:MIBIB";
+				reg = <0x50000 0x10000>;
+			};
+
+			partition@60000 {
+				label = "0:QSEE";
+				reg = <0x60000 0x180000>;
+			};
+
+			partition@1e0000 {
+				label = "0:DEVCFG";
+				reg = <0x1e0000 0x10000>;
+			};
+
+			partition@1f0000 {
+				label = "0:APDP";
+				reg = <0x1f0000 0x10000>;
+			};
+
+			partition@200000 {
+				label = "0:RPM";
+				reg = <0x200000 0x40000>;
+			};
+
+			partition@240000 {
+				label = "0:CDT";
+				reg = <0x240000 0x10000>;
+			};
+
+			partition@250000 {
+				label = "0:APPSBLENV";
+				reg = <0x250000 0x10000>;
+			};
+
+			partition@260000 {
+				label = "0:APPSBL";
+				reg = <0x260000 0xa0000>;
+			};
+
+			partition@300000 {
+				label = "0:ART";
+				reg = <0x300000 0x40000>;
+			};
+
+			partition@340000 {
+				label = "0:ETHPHYFW";
+				reg = <0x340000 0x80000>;
+			};
+
+			partition@3c0000 {
+				label = "product_info";
+				reg = <0x3c0000 0x10000>;
+			};
+
+			partition@3d0000 {
+				label = "mtdoops";
+				reg = <0x3d0000 0x20000>;
+			};
+
+			partition@3f0000 {
+				label = "priv_data1";
+				reg = <0x3f0000 0x10000>;
+			};
+		};
+	};
+};
+
+&blsp1_uart5 {
+	status = "okay";
+};
+
+&cryptobam {
+	status = "okay";
+};
+
+&crypto {
+	status = "okay";
+};
+
+&prng {
+	status = "okay";
+};
+
+&qpic_bam {
+	status = "okay";
+};
+
+&qpic_nand {
+	status = "okay";
+
+	nand@0 {
+		reg = <0>;
+		#address-cells = <0x01>;
+		#size-cells = <0x01>;
+		nand-ecc-strength = <0x04>;
+		nand-ecc-step-size = <0x200>;
+		nand-bus-width = <0x08>;
+
+		partition@0 {
+			label = "rootfs";
+			reg = <0x00 0x8000000>;
+		};
+	};
+};
+
+&mdio {
+	status = "okay";
+
+	pinctrl-0 = <&mdio_pins>;
+	pinctrl-names = "default";
+
+	qca8081_24: ethernet-phy@24 {
+		compatible = "ethernet-phy-id004d.d101";
+		reg = <24>;
+		reset-gpios = <&tlmm 25 GPIO_ACTIVE_LOW>;
+	};
+
+	qca8081_28: ethernet-phy@28 {
+		compatible = "ethernet-phy-id004d.d101";
+		reg = <28>;
+		reset-gpios = <&tlmm 44 GPIO_ACTIVE_LOW>;
+	};
+};
+
+&switch {
+	status = "okay";
+
+	switch_lan_bmp = <0x3e>; /* lan port bitmap */
+	switch_wan_bmp = <0x40>; /* wan port bitmap */
+	switch_mac_mode = <0>;   /* mac mode for uniphy instance0*/
+	switch_mac_mode1 = <0xf>; /* mac mode for uniphy instance1*/
+	switch_mac_mode2 = <0xf>; /* mac mode for uniphy instance2*/
+	bm_tick_mode = <0>; /* bm tick mode */
+	tm_tick_mode = <0>; /* tm tick mode */
+
+	qcom,port_phyinfo {
+		port@5 {
+			port_id = <5>;
+			phy_address = <24>;
+			port_mac_sel = "QGMAC_PORT";
+		};
+		port@6 {
+			port_id = <6>;
+			phy_address = <28>;
+			port_mac_sel = "QGMAC_PORT";
+		};
+	};
+};
+
+&edma {
+	status = "okay";
+};
+
+&dp5 {
+	status = "okay";
+	phy-handle = <&qca8081_24>;
+};
+
+&dp6 {
+	status = "okay";
+	phy-handle = <&qca8081_28>;
+};

--- a/target/linux/qualcommax/image/ipq807x.mk
+++ b/target/linux/qualcommax/image/ipq807x.mk
@@ -474,3 +474,16 @@ define Device/zyxel_nbg7815
 		kmod-bluetooth kmod-hwmon-tmp103
 endef
 TARGET_DEVICES += zyxel_nbg7815
+
+define Device/aliyun_ap8220
+	$(call Device/FitImage)
+	$(call Device/UbiFit)
+	DEVICE_VENDOR := Aliyun
+	DEVICE_MODEL := AP8220
+	BLOCKSIZE := 128k
+	PAGESIZE := 2048
+	DEVICE_DTS_CONFIG := config@ac02
+	SOC := ipq8071
+	IMAGE/factory.ubi := append-ubi | qsdk-ipq-factory-nand
+endef
+TARGET_DEVICES += aliyun_ap8220

--- a/target/linux/qualcommax/ipq807x/base-files/etc/board.d/02_network
+++ b/target/linux/qualcommax/ipq807x/base-files/etc/board.d/02_network
@@ -66,6 +66,9 @@ ipq807x_setup_interfaces()
 	zyxel,nbg7815)
 		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3 lan4 10g" "wan"
 		;;
+	aliyun,ap8220)
+		ucidef_set_interfaces_lan_wan "eth1" "eth0"
+		;;
 	*)
 		echo "Unsupported hardware. Network interfaces not initialized"
 		;;
@@ -97,7 +100,10 @@ ipq807x_setup_macs()
 			[ "$wan_mac" != "00:00:00:00:00:00" ] || wan_mac="$(get_mac_binary "$(find_mtd_chardev mac)" 0x20000)"
 			lan_mac="$(macaddr_add "$wan_mac" 1)"
 			label_mac="$wan_mac"
-
+		;;
+		aliyun,ap8220)
+			wan_mac=$(cat /dev/mtd12 | head -n 4 | grep "product.mac" | awk -F " " '{print $2}')
+			lan_mac=$(macaddr_add "$wan_mac" 1)
 		;;
 	esac
 

--- a/target/linux/qualcommax/ipq807x/base-files/lib/upgrade/platform.sh
+++ b/target/linux/qualcommax/ipq807x/base-files/lib/upgrade/platform.sh
@@ -210,6 +210,10 @@ platform_do_upgrade() {
 			mmc_do_upgrade "$1"
 		fi
 		;;
+	aliyun,ap8220)
+		CI_UBIPART="rootfs"
+		nand_do_upgrade "$1"
+		;;
 	*)
 		default_do_upgrade "$1"
 		;;


### PR DESCRIPTION
ImmortalWrt Aliyun AP8220 2.5G有线路由固件
感谢 @吕  大佬的修改

刷机方法：

先刷分区，参考： https://chi.miantiao.me/posts/aliyun-ap8220/

initramfs-uImage.itb 改名 ap8220.bin

```
tftpboot ap8220.bin

set boot3 "set mtdparts mtdparts=nand0:0x8000000@0x0(fs)"
set boot4 "ubi part fs && ubi read 42000000 kernel"
set setup1 "partname=1 && setenv bootargs ubi.mtd=rootfs ${args_common}"
set setup2 "partname=2 && setenv bootargs ubi.mtd=rootfs ${args_common}"

saveenv

bootm
```


改回 DHCP, 进后台刷新 sysupgrade.bin

进 SSH 执行

`chmod 644 /usr/share/rpcd/ucode/luci`


重启后应该就行了

ImmortalWrt 纯净固件，无 WiFi, 需要任何包可以自己装